### PR TITLE
refactor: update to implements InitializableDependency

### DIFF
--- a/lib/src/crashlytics_service.dart
+++ b/lib/src/crashlytics_service.dart
@@ -1,24 +1,19 @@
 import 'package:firebase_crashlytics/firebase_crashlytics.dart';
 import 'package:flutter/foundation.dart';
 import 'package:logger/logger.dart';
+import 'package:stacked/stacked_annotations.dart';
 
-class CrashlyticsService {
-  static CrashlyticsService? _instance;
+class CrashlyticsService implements InitializableDependency {
+  late FirebaseCrashlytics _instance;
 
-  static Future<CrashlyticsService> getInstance() async {
-    _instance ??= CrashlyticsService._(FirebaseCrashlytics.instance);
-
-    return _instance!;
+  @override
+  Future<void> init() async {
+    _instance = FirebaseCrashlytics.instance;
   }
-
-  final FirebaseCrashlytics _crashlyticsService;
-  CrashlyticsService._(
-    this._crashlyticsService,
-  );
 
   void recordFlutterErrorToCrashlytics(FlutterErrorDetails details) {
     try {
-      _crashlyticsService.recordFlutterError(details);
+      _instance.recordFlutterError(details);
     } catch (e) {
       _catchOrThrow(e);
     }
@@ -26,7 +21,7 @@ class CrashlyticsService {
 
   Future setUserIdToCrashlytics({String? id}) async {
     try {
-      if (id != null) await _crashlyticsService.setUserIdentifier(id);
+      if (id != null) await _instance.setUserIdentifier(id);
     } catch (e) {
       _catchOrThrow(e);
     }
@@ -39,8 +34,8 @@ class CrashlyticsService {
     required bool logwarnings,
   }) async {
     try {
-      if (level == Level.error || level == Level.wtf || level == Level.fatal) {
-        await _crashlyticsService.recordError(
+      if (level == Level.error || level == Level.fatal) {
+        await _instance.recordError(
           lines.join('\n'),
           stacktrace,
           printDetails: true,
@@ -48,17 +43,14 @@ class CrashlyticsService {
         );
       }
       if (level == Level.warning && logwarnings) {
-        await _crashlyticsService.recordError(
+        await _instance.recordError(
           lines.join('\n'),
           stacktrace,
           printDetails: true,
         );
       }
-      if (level == Level.info ||
-          level == Level.verbose ||
-          level == Level.trace ||
-          level == Level.debug) {
-        await _crashlyticsService.log(lines.join('\n'));
+      if (level == Level.info || level == Level.trace || level == Level.debug) {
+        await _instance.log(lines.join('\n'));
       }
     } catch (exception) {
       _catchOrThrow(exception);
@@ -67,7 +59,7 @@ class CrashlyticsService {
 
   Future setCustomKeysToTrack(String key, dynamic value) async {
     try {
-      await _crashlyticsService.setCustomKey(key, value);
+      await _instance.setCustomKey(key, value);
     } catch (e) {
       _catchOrThrow(e);
     }
@@ -77,7 +69,7 @@ class CrashlyticsService {
   // So, be sure to remove it after usage
   void crashApp() {
     try {
-      _crashlyticsService.crash();
+      _instance.crash();
     } catch (e) {
       _catchOrThrow(e);
     }
@@ -99,16 +91,16 @@ class CrashlyticsOutput extends LogOutput {
   CrashlyticsOutput({this.logWarnings = false});
 
   @override
-  void output(OutputEvent event) {
+  Future<void> output(OutputEvent event) async {
     try {
-      CrashlyticsService.getInstance().then((instance) {
-        return instance.logToCrashlytics(
-          event.level,
-          event.lines,
-          StackTrace.current,
-          logwarnings: logWarnings,
-        );
-      });
+      final service = CrashlyticsService();
+      await service.init();
+      return service.logToCrashlytics(
+        event.level,
+        event.lines,
+        StackTrace.current,
+        logwarnings: logWarnings,
+      );
     } catch (e) {
       if (kDebugMode) {
         print('CRASHLYTICS FAILED: $e');

--- a/lib/stacked_crashlytics.dart
+++ b/lib/stacked_crashlytics.dart
@@ -1,3 +1,4 @@
 library stacked_crashlytics;
 
 export 'src/crashlytics_service.dart';
+export 'package:logger/logger.dart' show Level;

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -16,6 +16,7 @@ dependencies:
   firebase_core: ^2.32.0
   firebase_crashlytics: ^3.5.7
   logger: ^2.3.0
+  stacked: ^3.4.3
 
 dev_dependencies:
   firebase_core_platform_interface: ^5.0.0

--- a/test/stacked_crashlytics_test.dart
+++ b/test/stacked_crashlytics_test.dart
@@ -10,8 +10,10 @@ void main() {
       setupFirebaseAuthMocks();
       Firebase.initializeApp();
     });
+
     test('when called, it should crash the app', () async {
-      var service = await CrashlyticsService.getInstance();
+      final service = CrashlyticsService();
+      await service.init();
       service.crashApp();
     });
   });


### PR DESCRIPTION
Refactored package to support `InitializableSingleton` on the locator using `InitializableDependency`.

Allows this

`InitializableSingleton(classType: CrashlyticsService),`

Instead of
```
Presolve(
    classType: CrashlyticsService,
    presolveUsing: CrashlyticsService.getInstance,
)
```

NOTE: Presolve was deprecated a while ago.

---

Also, export the `Level` class from the `logger` package to avoid unnecessary importing of the package on the client apps.